### PR TITLE
Fixa widget include-sökväg på Fraction CO2 sidan

### DIFF
--- a/varumarken/fraction-co2/index.php
+++ b/varumarken/fraction-co2/index.php
@@ -754,7 +754,7 @@ $specialists_view_more = 'Se alla hudterapeuter';
                             <div class="mb-xl"><?php echo $treatment_area->description ?></div>
                         <?php
                             foreach ($treatment_area->items as $treatment_area_item) {
-                                include('hudbehandlingar/widgets/treatment-area-item-card/treatment-area-item-card.php');
+                                include($_SERVER['DOCUMENT_ROOT'] . '/hudbehandlingar/widgets/treatment-area-item-card/treatment-area-item-card.php');
                             }
                         } ?>
                     </section>


### PR DESCRIPTION
- Bytte från relativ sökväg till absolut sökväg med $_SERVER['DOCUMENT_ROOT']
- Löser "Failed to open stream" fel för treatment-area-item-card widget
- Matchar hur andra brand-sidor i varumarken/ katalogen gör

🤖 Generated with [Claude Code](https://claude.ai/code)