### PR TITLE
Fixa redirect-problem och multiple H1-taggar

### DIFF
--- a/acne-ansikte.php
+++ b/acne-ansikte.php
@@ -171,7 +171,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Genom en anpassad hudvårdsrutin och rätt produkter kan vi effektivt förebygga akneutbrott och balansera din hud.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(
@@ -328,7 +328,7 @@ $products = array(
             consultation_url_title: 'Boka konsultation för hudvårdsprodukter mot akne',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             booking_url_title: 'Köp produktpaket mot akne',
       )
 );
@@ -780,7 +780,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/acne-brost.php
+++ b/acne-brost.php
@@ -111,7 +111,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Genom en anpassad hudvårdsrutin och rätt produkter kan vi effektivt förebygga akneutbrott och balansera din hud.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(
@@ -271,7 +271,7 @@ $products = array(
             consultation_url_title: 'Boka konsultation för hudvårdsprodukter mot akne',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             booking_url_title: 'Köp produktpaket mot akne',
       )
 );
@@ -725,7 +725,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/acne-rygg.php
+++ b/acne-rygg.php
@@ -199,7 +199,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Genom en anpassad hudvårdsrutin och rätt produkter kan vi effektivt förebygga akneutbrott och balansera din hud.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(
@@ -356,7 +356,7 @@ $products = array(
             consultation_url_title: 'Boka konsultation för hudvårdsprodukter mot akne',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             booking_url_title: 'Köp produktpaket mot akne',
       )
 );
@@ -806,7 +806,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/acne-scars.php
+++ b/acne-scars.php
@@ -71,7 +71,7 @@ $treatment_steps = array(
             title: 'Prevent',
             content: 'To prevent future acne outbreaks and minimize new scars, we offer specially developed skincare products and routines.',
             url_label: 'See products',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Find the best products to prevent acne and minimize scars'
       ),
       new TreatmentStep(
@@ -363,7 +363,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/acne-vulgaris.php
+++ b/acne-vulgaris.php
@@ -89,7 +89,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'FFör att förebygga framtida utbrott erbjuder vi resultatinriktade hudvårdsprodukter och rutiner.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga acne vulgaris'
       ),
       new TreatmentStep(
@@ -246,7 +246,7 @@ $products = array(
             consultation_url_title: 'Boka konsultation för hudvårdsprodukter mot akne',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             booking_url_title: 'Köp produktpaket mot akne',
       )
 );
@@ -719,7 +719,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/acne.php
+++ b/acne.php
@@ -111,7 +111,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Vi hjälper dig att hitta en hudvårdsrutin och produkter som passar din hudtyp för att förebygga ny akne och hålla din hud i balans.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(
@@ -533,7 +533,7 @@ $products = array(
             consultation_url: 'https://boka.acnespecialisten.se?flow=consultation&ConsultationType=Consultation_Problem&Consultationwhat=Consultation_Problem_Acne',
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot akne',
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             booking_url_title: 'Klicka för att köpa produktpaket mot akne',
       )
 );
@@ -1077,7 +1077,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/acnebehandling.php
+++ b/acnebehandling.php
@@ -172,7 +172,7 @@ $products = array(
         image_title: 'Acnespecialistens effektiva hudvårdsprodukter mot akne',
         image_alt: 'Bild på Acnespecialistens hudvårdsprodukter mot akne',
 
-        url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+        url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
         url_label: 'Utforska produkterna',
         url_title: 'Information om Acnespecialistens hudvårdsprodukter mot akne',
 

--- a/alma-hybrid-co2-laser.php
+++ b/alma-hybrid-co2-laser.php
@@ -4,7 +4,7 @@ include_once($_SERVER['DOCUMENT_ROOT'] . '/config.php');
 include_once($_SERVER['DOCUMENT_ROOT'] . '/includes/models.php');
 
 $seo_title = 'CO2 laser - Fraktionerad laser | AcneSpecialisten';
-$seo_description = 'Effektiv laserbehandling mot ärr, hudföryngring och mer hos AcneSpecialisten i Stockholm. Se resultat, före och efter bilder och boka din kostnadsfria konsultation idag.';
+$seo_description = 'Effektiv CO2 laser för ärr, hudföryngring och mer. Se resultat och boka kostnadsfri konsultation hos AcneSpecialisten.';
 $seo_keywords = 'co2 laser, fraktionerad laser, co2 laser före efter, fraktionerad laser före efter, co2 laser stockholm, koldioxidlaser, fraktionerad laser ärr, fraktionerad co2 laser';
 $seo_image = 'bilder/varumarken/424x456/alma-hybrid-co2.webp';
 

--- a/ansiktsbehandlingar.php
+++ b/ansiktsbehandlingar.php
@@ -4,7 +4,7 @@ include_once($_SERVER['DOCUMENT_ROOT'] . '/config.php');
 include_once($_SERVER['DOCUMENT_ROOT'] . '/includes/models.php');
 
 $seo_title = 'Ansiktsbehandling Stockholm | AcneSpecialisten';
-$seo_description = 'Stockholms bästa ansiktsbehandlingar på Östermalm, Södermalm & Sundbyberg. Skräddarsydda behandlingar för alla hudtyper - från återfuktning till lyxbehandlingar.';
+$seo_description = 'Stockholms bästa ansiktsbehandlingar. Skräddarsydda behandlingar för alla hudtyper hos AcneSpecialisten.';
 $seo_keywords = 'ansiktsbehandling, ansiktsbehandling stockholm, ansiktsbehandling östermalm, ansiktsbehandling södermalm, ansiktsbehandling sundbyberg, bästa ansiktsbehandling stockholm, bästa ansiktsbehandlning stockholm, ansiktsbehandling man';
 
 $seo_image = 'bilder/hudbehandlingar/424x456/klassiska-ansiktsbehandlingar.webp';

--- a/behandla-finnar-arr.php
+++ b/behandla-finnar-arr.php
@@ -371,7 +371,7 @@ $brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
     new Brand(

--- a/behandla-stora-porer.php
+++ b/behandla-stora-porer.php
@@ -257,7 +257,7 @@ $brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
     new Brand(

--- a/blandhy.php
+++ b/blandhy.php
@@ -129,7 +129,7 @@ $treatment_steps = array(
             content: 'För att bibehålla resultaten av behandlingarna är det viktigt med rätt hudvård hemma. Vi rekommenderar produkter speciellt anpassade för blandhy.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/blandhy',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/blandhy',
             url_title: 'Bläddra bland våra produkter för blandhy'
       ),
 
@@ -332,7 +332,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot blandhy',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/blandhy',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/blandhy',
             booking_url_title: 'Klicka för att köpa produktpaket mot blandhy',
       )
 );
@@ -573,7 +573,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/cystisk-acne.php
+++ b/cystisk-acne.php
@@ -71,7 +71,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att förebygga utbrott av cystisk akne erbjuder vi hudvårdsprodukter kombinerat med hudvårdsrutiner som hjälper till att balansera huden och bekämpa de faktorer som orsakar cystorna.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga cystisk akne'
       ),
       new TreatmentStep(
@@ -531,7 +531,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/fet-hy.php
+++ b/fet-hy.php
@@ -73,7 +73,7 @@ $treatment_steps = array(
             content: 'Vi ger råd om hudvårdsrutiner och produkter som är idealiska för fet hy, för att hjälpa dig att förebygga framtida hudproblem och bibehålla en hälsosam hudton.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/blandhy',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/blandhy',
             url_title: 'Bläddra bland våra produkter för fet hy'
       ),
 );
@@ -193,7 +193,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot fet hy',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/blandhy',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/blandhy',
             booking_url_title: 'Klicka för att köpa produktpaket mot fet hy',
       )
 );
@@ -343,7 +343,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/finnar-ansikte.php
+++ b/finnar-ansikte.php
@@ -77,7 +77,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Vi hjälper dig att hitta en hudvårdsrutin och produkter som passar din hudtyp för att förebygga nya finnar och hålla din hud i balans.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga finnar'
       ),
       new TreatmentStep(
@@ -229,7 +229,7 @@ $products = array(
             booking_url: null,
             booking_url_label: null,
             booking_url_title: null,
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
             url_label: 'Läs mer om produkterna',
             url_title: 'Klicka här för att läsa mer om våra effektiva produkter mot finnar'
       )
@@ -703,7 +703,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/finnar-arr.php
+++ b/finnar-arr.php
@@ -593,7 +593,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/finnar-behandling.php
+++ b/finnar-behandling.php
@@ -139,7 +139,7 @@ $products = array(
         image_title: 'Acnespecialistens effektiva hudvårdsprodukter mot finnar',
         image_alt: 'Bild på Acnespecialistens hudvårdsprodukter mot finnar',
 
-        url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+        url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
         url_label: 'Utforska våra hudvårdsprodukterna',
         url_title: 'Information om Acnespecialistens hudvårdsprodukter mot finnar',
         price: 'Acnespecialistens hudvårdsprodukter mot finnar - Från 1495 kr',
@@ -575,7 +575,7 @@ $brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
     new Brand(

--- a/finnar-brost.php
+++ b/finnar-brost.php
@@ -96,7 +96,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att motverka finnar på bröstet erbjuder vi specialutvecklade hudvårdsprodukter och rutiner. Dessa är framtagna för att bibehålla en sund hudbalans och förebygga framtida utbrott.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga finnar'
       ),
       new TreatmentStep(
@@ -237,7 +237,7 @@ $products = array(
             booking_url: null,
             booking_url_label: null,
             booking_url_title: null,
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
             url_label: 'Läs mer om produkterna',
             url_title: 'Klicka här för att läsa mer om våra effektiva produkter mot finnar'
       )
@@ -728,7 +728,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/finnar-gravid.php
+++ b/finnar-gravid.php
@@ -139,7 +139,7 @@ $treatment_steps = array(
             content: 'Vi erbjuder specialanpassade hudvårdsprodukter och rutiner som är säkra under graviditeten för att effektivt förebygga finnar och underhålla en sund hudbalans.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(
@@ -219,7 +219,7 @@ $products = array(
             booking_url: null,
             booking_url_label: null,
             booking_url_title: null,
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
             url_label: 'Läs mer om produkterna',
             url_title: 'Klicka här för att läsa mer om våra effektiva produkter mot finnar'
       )
@@ -695,7 +695,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/finnar-rygg.php
+++ b/finnar-rygg.php
@@ -144,7 +144,7 @@ $treatment_steps = array(
             title: 'Förebygg',
             content: 'Vi rekommenderar skräddarsydda hudvårdsprodukter och rutiner för att ta bort och förebygga utbrott.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga finnar på ryggen'
       ),
       new TreatmentStep(
@@ -283,7 +283,7 @@ $products = array(
             booking_url: null,
             booking_url_label: null,
             booking_url_title: null,
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
             url_label: 'Läs mer om produkterna',
             url_title: 'Klicka här för att läsa mer om våra effektiva produkter mot finnar'
       )
@@ -756,7 +756,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/finnar.php
+++ b/finnar.php
@@ -107,7 +107,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att hålla finnarna borta och din hud i balans erbjuder vi en personlig hudvårdsrutin och produkter som är särskilt anpassade för din hudtyp.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
             url_title: 'Hitta de bästa produkterna för att förebygga finnar'
       ),
       new TreatmentStep(
@@ -448,7 +448,7 @@ $products = array(
             booking_url: null,
             booking_url_label: null,
             booking_url_title: null,
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/finnar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/finnar',
             url_label: 'Läs mer om produkterna',
             url_title: 'Klicka här för att läsa mer om våra effektiva produkter mot finnar'
       )
@@ -958,7 +958,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/fragor-svar.php
+++ b/fragor-svar.php
@@ -102,7 +102,7 @@ $faq_categories = array(
 
     <title class="l10n">Frågor & svar - AcneSpecialisten</title>
     <meta name="title" content="Frågor & Svar - AcneSpecialisten" class="l10n">
-    <meta name="description" content="Frågor & svar AcneSpecialisten, här får du svar på några av de vanligaste frågorna" class="l10n">
+    <meta name="description" content="Få svar på vanliga frågor om hudvård och behandlingar hos AcneSpecialisten. Läs om bokning, priser och eftervård." class="l10n">
     <meta name="keywords" content="hudvård, acnebehandling, hudproblem, frågor och svar, AcneSpecialisten, hudterapi" class="l10n">
 
     <?php include($_SERVER['DOCUMENT_ROOT'] . '/includes/head.php'); ?>

--- a/hormonell-acne.php
+++ b/hormonell-acne.php
@@ -66,7 +66,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att förebygga framtida utbrott av hormonell acne, erbjuder vi specialdesignade produkter och rutiner.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga hormonell acne'
       ),
       new TreatmentStep(

--- a/hudbehandlingar/ansiktsbehandling/akne/index.php
+++ b/hudbehandlingar/ansiktsbehandling/akne/index.php
@@ -337,7 +337,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
     new Brand(

--- a/hudbehandlingar/ansiktsbehandling/rosacea/index.php
+++ b/hudbehandlingar/ansiktsbehandling/rosacea/index.php
@@ -146,7 +146,7 @@ $treatment_steps = array(
         title: 'Förebygga',
         content: 'Vi hjälper dig att hitta en hudvårdsrutin och produkter som passar din hudtyp för att förebygga ny rosacea och hålla din hud i balans.',
         url_label: 'Se produkter',
-        url: 'https://dahlskincare.se/produktkategorier/produktpaket/rosacea',
+        url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea',
         url_title: 'Hitta de bästa produkterna för att förebygga rosacea'
     ),
     new TreatmentStep(

--- a/hudbehandlingar/pormaskar/index.php
+++ b/hudbehandlingar/pormaskar/index.php
@@ -160,7 +160,7 @@ $products = array(
         image_title: 'AcneSpecialistens effektiva hudvårdsprodukter mot pormaskar',
         image_alt: 'Bild på AcneSpecialistens hudvårdsprodukter mot pormaskar',
 
-        url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+        url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
         url_label: 'Utforska hudvårdsprodukterna',
         url_title: 'Information om AcneSpecialistens hudvårdsprodukter mot pormaskar',
         price: 'AcneSpecialistens hudvårdsprodukter mot pormaskar - Från 1495 kr',
@@ -311,7 +311,7 @@ $brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
     new Brand(

--- a/hudbehandlingar/vaxning/index.php
+++ b/hudbehandlingar/vaxning/index.php
@@ -645,7 +645,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/includes/footer.php
+++ b/includes/footer.php
@@ -12,19 +12,19 @@
         </div>
         <div class="container">
             <div id="footer-brands">
-                <a href="https://www.klarna.se" target="_blank">
+                <a href="https://www.klarna.com/se/" target="_blank">
                     <img loading="lazy" src="bilder/logotyper/brand-icon-klarna.png" alt="Klarna" title="Klarna" width="40" height="40" />
                 </a>
                 <a href="https://www.americanexpress.com/sv-se/" target="_blank">
                     <img loading="lazy" src="images/brands/brand-icon-amex.svg" alt="Amex" title="Amex" width="40" height="40" />
                 </a>
-                <a href="https://www.qliro.com/sv-se" target="_blank">
+                <a href="https://qliro.com/sv/" target="_blank">
                     <img loading="lazy" src="images/brands/brand-icon-qliro.svg" alt="Qliro" title="Qliro" width="40" height="40" />
                 </a>
                 <a href="https://www.swish.nu" target="_blank">
                     <img loading="lazy" src="images/brands/brand-icon-swish.svg" alt="Swish" title="Swish" width="40" height="40" />
                 </a>
-                <a href="https://www.if.se" target="_blank">
+                <a href="https://www.if.se/privat" target="_blank">
                     <img loading="lazy" src="images/brands/brand-icon-if.svg" alt="If" title="If" width="40" height="40" />
                 </a>
                 <a href="https://www.shr.nu" target="_blank">
@@ -55,7 +55,7 @@
                             <p class="p200">Strandvägen 7, 114 51 Stockholm</p>
                         </div>
                     </div>
-                    <a href="https://www.bokadirekt.se/places/acnespecialisten-sveriges-sk%C3%B6nhetscenter-%C3%B6stermalm-43559" target="_blank" class="button grey expand l10n" title="Book a visit">Boka ett besök</a>
+                    <a href="https://www.bokadirekt.se/places/sveriges-skonhetscenter-acnespecialisten-ostermalm-43559" target="_blank" class="button grey expand l10n" title="Book a visit">Boka ett besök</a>
                 </div>
                 <div class="salon-card">
                     <div class="flex-row">
@@ -65,7 +65,7 @@
                             <p class="p200">Hornsgatan 47, 118 49 Stockholm</p>
                         </div>
                     </div>
-                    <a href="https://www.bokadirekt.se/places/acnespecialisten-sveriges-sk%C3%B6nhetscenter-s%C3%B6dermalm-19301" target="_blank" class="button grey expand l10n" title="Book a visit">Boka ett besök</a>
+                    <a href="https://www.bokadirekt.se/places/sveriges-skonhetscenter-acnespecialisten-sodermalm-19301" target="_blank" class="button grey expand l10n" title="Book a visit">Boka ett besök</a>
                 </div>
                 <div class="salon-card">
                     <div class="flex-row">
@@ -75,7 +75,7 @@
                             <p class="p200">Sturegatan 32, 172 31 Sundbyberg</p>
                         </div>
                     </div>
-                    <a href="https://www.bokadirekt.se/places/acnespecialisten-sveriges-sk%C3%B6nhetscenter-sundbyberg-19300" target="_blank" class="button grey expand l10n" title="Book a visit">Boka ett besök</a>
+                    <a href="https://www.bokadirekt.se/places/sveriges-skonhetscenter-acnespecialisten-sundbyberg-19300" target="_blank" class="button grey expand l10n" title="Book a visit">Boka ett besök</a>
                 </div>
             </div>
             <div id="footer-links">
@@ -316,13 +316,13 @@
                     <div>
                         <div class="flex-row">
                             <span class="h200 l10n">Betalningsmetoder</span>
-                            <a href="https://www.klarna.com" target="_blank">
+                            <a href="https://www.klarna.com/se/" target="_blank">
                                 <img loading="lazy" src="bilder/logotyper/brand-icon-klarna.png" alt="Klarna" title="Klarna" width="40" height="40" />
                             </a>
-                            <a href="https://www.amex.com" target="_blank">
+                            <a href="https://www.americanexpress.com/sv-se/" target="_blank">
                                 <img loading="lazy" src="images/brands/brand-icon-amex.svg" alt="Amex" title="Amex" width="40" height="40" />
                             </a>
-                            <a href="https://www.qliro.com/sv-se" target="_blank">
+                            <a href="https://qliro.com/sv/" target="_blank">
                                 <img loading="lazy" src="images/brands/brand-icon-qliro.svg" alt="Qliro" title="Qliro" width="40" height="40" />
                             </a>
                             <a href="https://www.swish.nu" target="_blank">
@@ -333,7 +333,7 @@
                     <div>
                         <div class="flex-row justify-end">
                             <span class="h200 l10n">Patientskadeförsäkrings hos IF</span>
-                            <a href="https://www.if.se" target="_blank">
+                            <a href="https://www.if.se/privat" target="_blank">
                                 <img loading="lazy" src="images/brands/brand-icon-if.svg" alt="If" title="If" width="40" height="40" />
                             </a>
                         </div>
@@ -372,7 +372,7 @@
                             <div>
                                 <h2>Östermalm</h2>
                                 <p class="p200">Strandvägen 7, 114 51 Stockholm</p>
-                                <a href="https://www.bokadirekt.se/places/acnespecialisten-sveriges-sk%C3%B6nhetscenter-%C3%B6stermalm-43559" target="_blank" class="button b200 compact text l10n" title="Boka tid">Boka tid</a>
+                                <a href="https://www.bokadirekt.se/places/sveriges-skonhetscenter-acnespecialisten-ostermalm-43559" target="_blank" class="button b200 compact text l10n" title="Boka tid">Boka tid</a>
                             </div>
                         </div>
                     </div>
@@ -382,7 +382,7 @@
                             <div>
                                 <h2>Södermalm</h2>
                                 <p class="p200">Hornsgatan 47, 118 49 Stockholm</p>
-                                <a href="https://www.bokadirekt.se/places/acnespecialisten-sveriges-sk%C3%B6nhetscenter-s%C3%B6dermalm-19301" target="_blank" class="button b200 compact text l10n" title="Boka tid">Boka tid</a>
+                                <a href="https://www.bokadirekt.se/places/sveriges-skonhetscenter-acnespecialisten-sodermalm-19301" target="_blank" class="button b200 compact text l10n" title="Boka tid">Boka tid</a>
                             </div>
                         </div>
                     </div>
@@ -392,7 +392,7 @@
                             <div>
                                 <h2>Sundbyberg</h2>
                                 <p class="p200">Sturegatan 32, 172 31 Sundbyberg</p>
-                                <a href="https://www.bokadirekt.se/places/acnespecialisten-sveriges-sk%C3%B6nhetscenter-sundbyberg-19300" target="_blank" class="button b200 compact text l10n" title="Boka tid">Boka tid</a>
+                                <a href="https://www.bokadirekt.se/places/sveriges-skonhetscenter-acnespecialisten-sundbyberg-19300" target="_blank" class="button b200 compact text l10n" title="Boka tid">Boka tid</a>
                             </div>
                         </div>
 

--- a/includes/widgets/brands/brands.php
+++ b/includes/widgets/brands/brands.php
@@ -118,7 +118,7 @@ if (!isset($brands)) {
                   image: 'bilder/logotyper/dahl-skincare.webp',
                   image_alt: 'DAHL Skincare logotyp',
                   image_title: 'DAHL Skincare - hudvårdsprodukter',
-                  url: 'https://dahlskincare.se',
+                  url: 'https://www.dahlskincare.com/sv/,
                   url_title: 'DAHL Skincare',
             ),
       );

--- a/includes/widgets/green_header_banner/treatment_green_header_banner.php
+++ b/includes/widgets/green_header_banner/treatment_green_header_banner.php
@@ -46,9 +46,9 @@
                 <?php include($_SERVER['DOCUMENT_ROOT'] . '/includes/widgets/badges/badges.php'); ?>
             </div>
             <div id="green-header-large-text" class="mt-xxs">
-                <h1 class="h600">
+                <div class="h600">
                     <?php echo $model->title ?>
-                </h1>
+                </div>
                 <?php if (isset($model->duration)) { ?>
                     <div class="mt-xs">
                         <span class="p200 l10n">Längd: <?php echo $model->duration ?></span>

--- a/index.php
+++ b/index.php
@@ -223,7 +223,7 @@
                                     title: 'Förebygga',
                                     content: 'För att förebygga framtida hudproblem och bibehålla resultatet av behandlingarna rekommenderar vi produkter och rutiner som är anpassade efter din hudtyp och specifika problem.',
                                     button_label: 'Se produkter',
-                                    button_url: 'https://dahlskincare.se',
+                                    button_url: 'https://www.dahlskincare.com/sv/,
                                     button_url_title: 'Besök vår webbshop',
                                     button_url_target: '_blank',
                               ),

--- a/inflammation-acne.php
+++ b/inflammation-acne.php
@@ -66,7 +66,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att förebygga framtida utbrott av inflammatorisk akne, erbjuder vi specialutvecklade hudvårdsprodukter och rutiner.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga inflammatorisk akne'
       ),
       new TreatmentStep(
@@ -522,7 +522,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/klamma-finnar.php
+++ b/klamma-finnar.php
@@ -548,7 +548,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/komedoner.php
+++ b/komedoner.php
@@ -70,7 +70,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'Vi hjälper vi dig att etablera en anpassad hudvårdsrutin. Vi väljer ut produkter som är idealiska för din hudtyp för att effektivt förebygga komedoner och upprätthålla en hälsosam hudbalans.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             url_label: 'Se produkter',
             url_title: 'Hitta de bästa produkterna för att förebygga komedoner'
       ),
@@ -237,7 +237,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/laser-acne.php
+++ b/laser-acne.php
@@ -553,7 +553,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/mallorca-acne.php
+++ b/mallorca-acne.php
@@ -66,7 +66,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att förebygga framtida utbrott av Mallorca akne erbjuder vi skräddarsydda hudvårdsprodukter och rutiner. Dessa är särskilt utformade för att balansera huden och motverka de faktorer som bidrar till problemet.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga Mallorca akne'
       ),
       new TreatmentStep(
@@ -520,7 +520,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/metoden.php
+++ b/metoden.php
@@ -31,7 +31,7 @@ $steps = array(
         content: "För att säkerställa långsiktiga resultat fokuserar vi på att förebygga framtida hudproblem. Vi ger dig skräddarsydd hudvårdsrutin och rekommenderar högkvalitativa hudvårdsprodukter som är anpassade för att skydda och upprätthålla din huds hälsa.",
         image_small: '/bilder/metoden/mobile/metoden-forebygga.webp',
         image_large: '/bilder/metoden/desktop/metoden-forebygga.webp',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_label: 'Upptäck produkterna',
         url_title: 'Se produkterna',
         url_target: '_blank',

--- a/mjalleksem.php
+++ b/mjalleksem.php
@@ -68,7 +68,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'På AcneSpecialisten hjälper vi dig att hitta en skräddarsydd hudvårdsrutin och produkter specifikt för att förebygga mjälleksem, och att hålla din hud frisk och balanserad.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/seborre',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/seborre',
             url_label: 'Upptäck produkterna',
             url_title: 'Se produkterna för att förebygga mjälleksem',
       ),
@@ -177,7 +177,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot mjälleksem',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/seborre',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/seborre',
             booking_url_title: 'Klicka för att köpa produktpaket mot mjälleksem',
       )
 );
@@ -307,7 +307,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/not-found.php
+++ b/not-found.php
@@ -7,7 +7,7 @@
     <link rel="canonical" href="https://www.acnespecialisten.se/not-found.php" />
 
     <title>Sidan hittas ej | AcneSpecialisten – Hudvård i Stockholm</title>
-    <meta name="description" content="Läs om AcneSpecialistens Sidan hittas ej.">
+    <meta name="description" content="Sidan hittades inte. Kontakta AcneSpecialisten för hjälp med hudvård och behandlingar i Stockholm.">
     <meta name="keywords" content="Sidan hittas ej">
 
     <?php include($_SERVER['DOCUMENT_ROOT'] . '/includes/head.php'); ?>

--- a/perioral-dermatit.php
+++ b/perioral-dermatit.php
@@ -98,7 +98,7 @@ $treatment_steps = array(
             content: 'Vi hjälper dig att finna en hudvårdsrutin och rekommenderar produkter speciellt anpassade för hudtypen.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/perioral-dermatit',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/perioral-dermatit',
             url_title: 'Hitta de bästa produkterna för att förebygga perioral dermatit',
       ),
 );
@@ -402,7 +402,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot perioral dermatit',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/perioral-dermatit',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/perioral-dermatit',
             booking_url_title: 'Klicka för att köpa produktpaket mot perioral dermatit',
       )
 );
@@ -575,7 +575,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/permanent-harborttagning.php
+++ b/permanent-harborttagning.php
@@ -743,7 +743,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/pormaskar-rygg.php
+++ b/pormaskar-rygg.php
@@ -70,7 +70,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'Vårt mål är att hjälpa dig att utveckla en hudvårdsrutin som effektivt kan förebygga uppkomsten av nya pormaskar på ryggen. Genom att använda specifikt utvalda produkter anpassade för din hudtyp, arbetar vi tillsammans för att bibehålla din huds optimala hälsa och förebygga framtida problem.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             url_label: 'Se produkter',
             url_title: 'Upptäck de bästa produkterna för att förebygga pormaskar på ryggen',
       ),
@@ -313,7 +313,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/pormaskar.php
+++ b/pormaskar.php
@@ -100,7 +100,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'Vi hjälper dig att hitta en hudvårdsrutin och produkter som passar din hudtyp för att förebygga nya pormaskar och hålla din hud i balans.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             url_label: 'Se produkter',
             url_title: 'Hitta de bästa produkterna för att förebygga pormaskar'
       ),
@@ -425,7 +425,7 @@ $products = array(
             consultation_url_label: 'Boka konsultation',
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för portömning',
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             booking_url_title: 'Klicka för att köpa produktpaket mot pormaskar',
       )
 );
@@ -689,7 +689,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/porrengoring.php
+++ b/porrengoring.php
@@ -455,7 +455,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/portomning.php
+++ b/portomning.php
@@ -461,7 +461,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/postinflammatorisk-hyperpigmentering.php
+++ b/postinflammatorisk-hyperpigmentering.php
@@ -298,7 +298,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/problemhy.php
+++ b/problemhy.php
@@ -600,7 +600,7 @@ $all_brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
 );

--- a/resultat-acne.php
+++ b/resultat-acne.php
@@ -126,13 +126,13 @@ $results = [
         image_url: 'bilder/resultat/744x496/resultat-akne-1.jpg',
         image_alt: 'Före och efter bild på kund med akne',
         image_title: 'Före och efter bild på kund med akne',
-        content: '<a href="acne.php">Acne</a> behandlat med <a href="acnebehandling.php">Acnebehandling</a> och <a href="https://dahlskincare.se/produktkategorier/produktpaket/akne">produktpaket mot akne</a>.',
+        content: '<a href="acne.php">Acne</a> behandlat med <a href="acnebehandling.php">Acnebehandling</a> och <a href="https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne">produktpaket mot akne</a>.',
     ),
     new LabelImage(
         image_url: 'bilder/resultat/744x496/resultat-akne-2.jpg',
         image_alt: 'Före och efter bild på kund med akne',
         image_title: 'Före och efter bild på kund med akne',
-        content: '<a href="acne.php">Acne</a> behandlat med <a href="acnebehandling.php">Ansiktsbehandling mot acne</a> och <a href="https://dahlskincare.se/produktkategorier/produktpaket/akne">produktpaket mot akne</a>.',
+        content: '<a href="acne.php">Acne</a> behandlat med <a href="acnebehandling.php">Ansiktsbehandling mot acne</a> och <a href="https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne">produktpaket mot akne</a>.',
     ),
 ];
 

--- a/resultat-pormaskar.php
+++ b/resultat-pormaskar.php
@@ -94,7 +94,7 @@ $results = [
         image_url: 'bilder/resultat/744x496/resultat-pormaskar-1.jpg',
         image_alt: 'Före och efter bild på kund med pormaskar',
         image_title: 'Före och efter bild på kund med pormaskar',
-        content: '<a href="pormaskar.php">Pormaskar</a> behandlat med <a href="portomning.php">portömning</a> och <a href="https://dahlskincare.se/produktkategorier/produktpaket/pormaskar">produktpaket mot pormaskar</a>.',
+        content: '<a href="pormaskar.php">Pormaskar</a> behandlat med <a href="portomning.php">portömning</a> och <a href="https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar">produktpaket mot pormaskar</a>.',
     ),
 ];
 

--- a/resultat-rosacea.php
+++ b/resultat-rosacea.php
@@ -107,7 +107,7 @@ $results = [
         image_url: 'bilder/resultat/744x496/resultat-rosacea-1.jpg',
         image_alt: 'Före och efter bild på kund med rosacea',
         image_title: 'Före och efter bild på kund med rosacea',
-        content: '<a href="rosacea.php">Rosacea</a> som behandlats med <a href="https://dahlskincare.se/produktkategorier/produktpaket/rosacea">rosaceabehandling</a> och <a href="rosaceabehandling.php">produktpaket för rosacea</a>',
+        content: '<a href="rosacea.php">Rosacea</a> som behandlats med <a href="https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea">rosaceabehandling</a> och <a href="rosaceabehandling.php">produktpaket för rosacea</a>',
     ),
 ];
 ?>

--- a/resultat-stora-porer.php
+++ b/resultat-stora-porer.php
@@ -97,7 +97,7 @@ $results = [
         image_url: 'bilder/resultat/744x496/resultat-stora-porer-1.jpg',
         image_alt: 'Före och efter bild på kund med stora porer',
         image_title: 'Före och efter bild på kund med stora porer',
-        content: '<a href="stora-porer.php">Stora porer</a> behandlat med <a href="portomning.php">portömning</a> och <a href="https://dahlskincare.se/produktkategorier/produktpaket/pormaskar">produktpaket mot stora porer</a>.',
+        content: '<a href="stora-porer.php">Stora porer</a> behandlat med <a href="portomning.php">portömning</a> och <a href="https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar">produktpaket mot stora porer</a>.',
     ),
 ];
 

--- a/rhinophyma-rosacea.php
+++ b/rhinophyma-rosacea.php
@@ -59,7 +59,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Vi hjälper dig att hitta en hudvårdsrutin och produkter som passar din hudtyp för att förebygga ny rhinophyma rosacea och hålla din hud i balans.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/rosacea',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea',
             url_title: 'Hitta de bästa produkterna för att förebygga rosacea'
       ),
       new TreatmentStep(
@@ -181,7 +181,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot rosacea',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/rosacea',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea',
             booking_url_title: 'Klicka för att köpa produktpaket mot rosacea',
       )
 );
@@ -492,7 +492,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/rosacea.php
+++ b/rosacea.php
@@ -97,7 +97,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Vi hjälper dig att hitta en hudvårdsrutin och produkter som passar din hudtyp för att förebygga ny rosacea som håller din hy i balans.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/rosacea',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea',
             url_title: 'Hitta de bästa produkterna för att förebygga rosacea'
       ),
       new TreatmentStep(
@@ -307,7 +307,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot rosacea',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/rosacea',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea',
             booking_url_title: 'Klicka för att köpa produktpaket mot rosacea',
       )
 );
@@ -676,7 +676,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/rosaceabehandling.php
+++ b/rosaceabehandling.php
@@ -113,7 +113,7 @@ $products = array(
         image_title: 'Acnespecialistens effektiva hudvårdsprodukter mot rosacea',
         image_alt: 'Bild på Acnespecialistens hudvårdsprodukter mot rosacea',
 
-        url: 'https://dahlskincare.se/produktkategorier/produktpaket/rosacea',
+        url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/rosacea',
         url_label: 'Utforska hudvårdsprodukterna',
         url_title: 'Information om Acnespecialistens hudvårdsprodukter mot rosacea',
         price: 'Hudvårdsprodukter mot rosacea - Från 1495 kr',
@@ -362,7 +362,7 @@ $brands = array(
         image: 'bilder/logotyper/dahl-skincare.webp',
         image_alt: 'DAHL Skincare logotyp',
         image_title: 'DAHL Skincare - hudvårdsprodukter',
-        url: 'https://dahlskincare.se',
+        url: 'https://www.dahlskincare.com/sv/,
         url_title: 'DAHL Skincare',
     ),
     new Brand(

--- a/seborre.php
+++ b/seborre.php
@@ -96,7 +96,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'På AcneSpecialisten hjälper vi dig att hitta en skräddarsydd hudvårdsrutin och produkter specifikt för att förebygga seborré, och att hålla din hud frisk, balanserad och problemfri.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/seborre',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/seborre',
             url_label: 'Se produkter',
             url_title: 'Se produkterna för att förebygga seborré',
       ),
@@ -222,7 +222,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot seborré',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/seborre',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/seborre',
             booking_url_title: 'Klicka för att köpa produktpaket mot seborré',
       )
 );
@@ -394,7 +394,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/seborroisk-keratos.php
+++ b/seborroisk-keratos.php
@@ -373,7 +373,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/stora-porer.php
+++ b/stora-porer.php
@@ -98,7 +98,7 @@ $treatment_steps = array(
             content: 'Vi tar fram en hudvårdsrutin och produkter som är anpassade efter din hudtyp. Målet är att förebygga stora porer och bibehålla en balanserad hud.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             url_title: 'Hitta de bästa produkterna för att förebygga stora porer'
       ),
 
@@ -310,7 +310,7 @@ $products = array(
             consultation_url_label: 'Boka konsultation',
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för stora porer',
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             booking_url_title: 'Klicka för att köpa produktpaket mot stora porer',
       )
 );
@@ -578,7 +578,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/stress-acne.php
+++ b/stress-acne.php
@@ -66,7 +66,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'För att minska risken för framtida acneutbrott, erbjuder vi hudvårdsprodukter och rutiner som hjälper till att upprätthålla en hälsosam hudbalans.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga stress acne'
       ),
       new TreatmentStep(
@@ -558,7 +558,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/stress-finnar.php
+++ b/stress-finnar.php
@@ -69,7 +69,7 @@ $treatment_steps = array(
             content: 'Vi erbjuder skräddarsydda hudvårdsrutiner och produkter som är utformade för att förebygga uppkomsten av finnar och upprätthålla en hälsosam hudbalans.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(
@@ -559,7 +559,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/studentrabatt/index.php
+++ b/studentrabatt/index.php
@@ -128,8 +128,8 @@ $path_segments = [
                                     </div>
                                     <div class="treatment-step-content">Vi ger dig skräddarsydd hudvårdsrutin och rekommenderar högkvalitativa hudvårdsprodukter som är anpassade för att behandla och förebygga ditt hudproblem.</div>
                                 </div>
-                                <a href="https://dahlskincare.se" class="button grey expand is-hidden-tablet" title="Se produkterna">Se produkterna</a>
-                                <a href="https://dahlskincare.se" class="button b200 text compact is-hidden-mobile" title="Boka gratis konsultation">Se produkterna</a>
+                                <a href="https://www.dahlskincare.com/sv/ class="button grey expand is-hidden-tablet" title="Se produkterna">Se produkterna</a>
+                                <a href="https://www.dahlskincare.com/sv/ class="button b200 text compact is-hidden-mobile" title="Boka gratis konsultation">Se produkterna</a>
                             </div>
                         </div>
                         <div class="column">

--- a/svarta-pormaskar.php
+++ b/svarta-pormaskar.php
@@ -70,7 +70,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'Vi hjälper dig att utveckla en anpassad hudvårdsrutin för att förebygga uppkomsten av nya svarta pormaskar. Genom att välja ut produkter som passar just din hudtyp, strävar vi efter att hjälpa dig upprätthålla en hälsosam hudbalans och förebygga framtida hudproblem.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             url_label: 'Se produkter',
             url_title: 'Hitta de bästa produkterna för att förebygga svarta pormaskar'
       ),
@@ -334,7 +334,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/tonarsacne.php
+++ b/tonarsacne.php
@@ -67,7 +67,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Vi skapar en personlig hudvårdsrutin som behandlar och balanserar din akne effektivt.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga tonårsakne'
       ),
       new TreatmentStep(
@@ -529,7 +529,7 @@ $brands = array(
             image: 'bilder/logotyper/dahl-skincare.webp',
             image_alt: 'DAHL Skincare logotyp',
             image_title: 'DAHL Skincare - hudvårdsprodukter',
-            url: 'https://dahlskincare.se',
+            url: 'https://www.dahlskincare.com/sv/,
             url_title: 'DAHL Skincare',
       ),
       new Brand(

--- a/torr-hy.php
+++ b/torr-hy.php
@@ -116,7 +116,7 @@ $treatment_steps = array(
             content: 'Vi hjälper dig att hitta en hudvårdsrutin som är anpassade för torr och känslig hud, för att förhindra framtida hudproblem och behålla hudens fuktbalans.',
 
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/day-n-night-duo',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/day-n-night-duo',
             url_title: 'Hitta de bästa produkterna för att förebygga hudproblem för torr och känslig hud'
       )
 
@@ -521,7 +521,7 @@ $products = array(
             consultation_url_title: 'Klicka för att boka tid för en hudkonsultation för hudvårdsprodukter mot torr och känslig hy',
 
             booking_url_label: 'Köp produkter',
-            booking_url: 'https://dahlskincare.se/produktkategorier/produktpaket/day-n-night-duo',
+            booking_url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/day-n-night-duo',
             booking_url_title: 'Klicka för att köpa produktpaket mot torr och känslig hy',
       ),
 );

--- a/vita-pormaskar.php
+++ b/vita-pormaskar.php
@@ -70,7 +70,7 @@ $treatment_steps = array(
       new TreatmentStep(
             title: 'Förebygga',
             content: 'Vårt team hjälper dig att skräddarsy en hudvårdsrutin för att effektivt förhindra nya pormaskar. Genom att noga välja ut produkter som matchar din hudtyp, arbetar vi för att bibehålla en sund hudbalans och förebygga framtida hudutmaningar.',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/pormaskar',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/pormaskar',
             url_label: 'Se produkter',
             url_title: 'Utforska de bästa produkterna för att förebygga vita pormaskar',
       ),

--- a/vuxenacne.php
+++ b/vuxenacne.php
@@ -68,7 +68,7 @@ $treatment_steps = array(
             title: 'Förebygga',
             content: 'Vi erbjuder anpassade produkter och rutiner som är speciellt utformade för att förebygga vuxenacne och bevara en hälsosam hudbalans.',
             url_label: 'Se produkter',
-            url: 'https://dahlskincare.se/produktkategorier/produktpaket/akne',
+            url: 'https://www.dahlskincare.com/sv/produktkategorier/produktpaket/akne',
             url_title: 'Hitta de bästa produkterna för att förebygga akne'
       ),
       new TreatmentStep(


### PR DESCRIPTION
- Uppdatera Dahlskincare-länkar från .se till .com/sv/ (113 länkar)
- Fixa Bokadirekt-länkar till korrekta destinationer (6 länkar)
- Korrigera betalningsleverantörs-URLs (Klarna, Qliro, IF, Amex)
- Lösa multiple H1-taggar på behandlingssidor genom att ändra desktop H1 till div

🤖 Generated with [Claude Code](https://claude.ai/code)