### PR TITLE
Fixa PHP syntaxfel med saknade citattecken och uppdatera webbshopstext

### DIFF
--- a/index.php
+++ b/index.php
@@ -223,8 +223,8 @@
                                     title: 'Förebygga',
                                     content: 'För att förebygga framtida hudproblem och bibehålla resultatet av behandlingarna rekommenderar vi produkter och rutiner som är anpassade efter din hudtyp och specifika problem.',
                                     button_label: 'Se produkter',
-                                    button_url: 'https://www.dahlskincare.com/sv/,
-                                    button_url_title: 'Besök vår webbshop',
+                                    button_url: 'https://www.dahlskincare.com/sv/',
+                                    button_url_title: 'Besök DAHL Skincares webbshop',
                                     button_url_target: '_blank',
                               ),
                               new ApproachCard(

--- a/metoden.php
+++ b/metoden.php
@@ -31,7 +31,7 @@ $steps = array(
         content: "För att säkerställa långsiktiga resultat fokuserar vi på att förebygga framtida hudproblem. Vi ger dig skräddarsydd hudvårdsrutin och rekommenderar högkvalitativa hudvårdsprodukter som är anpassade för att skydda och upprätthålla din huds hälsa.",
         image_small: '/bilder/metoden/mobile/metoden-forebygga.webp',
         image_large: '/bilder/metoden/desktop/metoden-forebygga.webp',
-        url: 'https://www.dahlskincare.com/sv/,
+        url: 'https://www.dahlskincare.com/sv/',
         url_label: 'Upptäck produkterna',
         url_title: 'Se produkterna',
         url_target: '_blank',


### PR DESCRIPTION
- Fixa saknade avslutande citattecken för URL:er i index.php och metoden.php
- Uppdatera text från 'Besök vår webbshop' till 'Besök DAHL Skincares webbshop' för att förtydliga att det är DAHL Skincares webbshop, inte vår egen

🤖 Generated with [Claude Code](https://claude.ai/code)