### PR TITLE
Fixa HTML-taggfel: ändra <dig> till <div> i alla PHP-filer

### DIFF
--- a/acne-ansikte.php
+++ b/acne-ansikte.php
@@ -964,13 +964,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/acne-brost.php
+++ b/acne-brost.php
@@ -906,13 +906,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/acne-rygg.php
+++ b/acne-rygg.php
@@ -988,13 +988,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/acne-scars.php
+++ b/acne-scars.php
@@ -509,13 +509,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/acne-vulgaris.php
+++ b/acne-vulgaris.php
@@ -901,13 +901,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/acne.php
+++ b/acne.php
@@ -1319,13 +1319,13 @@ $brands_url_title = "Varumärken för Aknebehandling";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/acnearr.php
+++ b/acnearr.php
@@ -779,13 +779,13 @@ $brands_url_title = "Varumärken för acneärr";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/aldersflackar.php
+++ b/aldersflackar.php
@@ -604,13 +604,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/atrofiska-arr.php
+++ b/atrofiska-arr.php
@@ -461,13 +461,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/blandhy.php
+++ b/blandhy.php
@@ -762,13 +762,13 @@ $brands_url_title = "Varumärken för Blandhybehandling";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/blodprickar.php
+++ b/blodprickar.php
@@ -514,13 +514,13 @@ $brands_url_title = "Se alla varumärken";
 
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
 
                   </div>

--- a/cystisk-acne.php
+++ b/cystisk-acne.php
@@ -675,13 +675,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/fet-hy.php
+++ b/fet-hy.php
@@ -518,13 +518,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/finnar-ansikte.php
+++ b/finnar-ansikte.php
@@ -884,13 +884,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/finnar-arr.php
+++ b/finnar-arr.php
@@ -787,13 +787,13 @@ $brands_url_title = "Varumärken för ärr";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/finnar-brost.php
+++ b/finnar-brost.php
@@ -920,13 +920,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/finnar-gravid.php
+++ b/finnar-gravid.php
@@ -878,13 +878,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/finnar-rygg.php
+++ b/finnar-rygg.php
@@ -947,13 +947,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/finnar.php
+++ b/finnar.php
@@ -1195,13 +1195,13 @@ $brands_url_title = "Varumärken för Aknebehandling";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/fodelsemarken.php
+++ b/fodelsemarken.php
@@ -562,13 +562,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/hormonell-acne.php
+++ b/hormonell-acne.php
@@ -656,13 +656,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/hudflikar.php
+++ b/hudflikar.php
@@ -566,13 +566,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/inflammation-acne.php
+++ b/inflammation-acne.php
@@ -660,13 +660,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/komedoner.php
+++ b/komedoner.php
@@ -388,13 +388,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/mallorca-acne.php
+++ b/mallorca-acne.php
@@ -658,13 +658,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/melasma.php
+++ b/melasma.php
@@ -476,13 +476,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/mjalleksem.php
+++ b/mjalleksem.php
@@ -475,13 +475,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/mogen-hy.php
+++ b/mogen-hy.php
@@ -843,13 +843,13 @@ $brands_url_title = "Varumärken för behandling av mogen hy";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/perioral-dermatit.php
+++ b/perioral-dermatit.php
@@ -798,13 +798,13 @@ $brands_url_title = "Varumärken för behandling av perioral dermatit";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/pigmentflackar.php
+++ b/pigmentflackar.php
@@ -714,13 +714,13 @@ $brands_url_title = "Varumärken för pigmentfläckar";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/pormaskar-rygg.php
+++ b/pormaskar-rygg.php
@@ -459,13 +459,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/pormaskar.php
+++ b/pormaskar.php
@@ -919,13 +919,13 @@ $brands_url_title = "Varumärken för pormaskar";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/postinflammatorisk-hyperpigmentering.php
+++ b/postinflammatorisk-hyperpigmentering.php
@@ -469,13 +469,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/rhinophyma-rosacea.php
+++ b/rhinophyma-rosacea.php
@@ -676,13 +676,13 @@ $brands_url_title = "Varumärken för rhinophyma rosaceabehandling";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/rosacea.php
+++ b/rosacea.php
@@ -911,13 +911,13 @@ $brands_url_title = "Varumärken för Rosaceabehandling";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/seborre.php
+++ b/seborre.php
@@ -661,13 +661,13 @@ $brands_url_title = "Varumärken för behandling av seoborré";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
             </div>

--- a/seborroisk-keratos.php
+++ b/seborroisk-keratos.php
@@ -536,13 +536,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/solskadad-hy.php
+++ b/solskadad-hy.php
@@ -385,13 +385,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/stora-porer.php
+++ b/stora-porer.php
@@ -775,13 +775,13 @@ $brands_url_title = "Varumärken för behandling av stora porer";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/stress-acne.php
+++ b/stress-acne.php
@@ -710,13 +710,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/stress-finnar.php
+++ b/stress-finnar.php
@@ -711,13 +711,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/svarta-pormaskar.php
+++ b/svarta-pormaskar.php
@@ -485,13 +485,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/tonarsacne.php
+++ b/tonarsacne.php
@@ -666,13 +666,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/torr-hy.php
+++ b/torr-hy.php
@@ -992,13 +992,13 @@ $brands_url_title = "Varumärken för behandling av torr och känslig hy";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/vita-pormaskar.php
+++ b/vita-pormaskar.php
@@ -458,13 +458,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/vuxenacne.php
+++ b/vuxenacne.php
@@ -668,13 +668,13 @@ $brands_url_title = "Se alla varumärken";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">

--- a/ytliga-blodkarl.php
+++ b/ytliga-blodkarl.php
@@ -816,13 +816,13 @@ $brands_url_title = "Varumärken för behandling av ytliga blodkärl";
                         </section>
                         <section id="related-problems">
                               <h2 class="big l10n">Relaterade hudproblem</h2>
-                              <dig class="columns is-variable is-0-mobile is-3-tablet is-multiline">
+                              <div class="columns is-variable is-0-mobile is-3-tablet is-multiline">
                                     <?php foreach ($related_problems as $problem) { ?>
                                           <div class="column is-half">
                                                 <?php include('hudproblem/widgets/related-problem-card/related-problem-card.php'); ?>
                                           </div>
                                     <?php } ?>
-                              </dig>
+                              </div>
                         </section>
                   </div>
                   <section id="brands">


### PR DESCRIPTION
- Fixade felstavade <dig> taggar till korrekta <div> taggar
- Fixade motsvarande </dig> stängningstaggar till </div>
- Påverkade 45+ PHP-filer med systematiskt HTML-fel
- Förbättrar HTML-validering och struktur på alla sidor

🤖 Generated with [Claude Code](https://claude.ai/code)